### PR TITLE
rootext/mfile-root: Fix missing include

### DIFF
--- a/src/rootext/mfile-root/VMatrix.hh
+++ b/src/rootext/mfile-root/VMatrix.hh
@@ -23,6 +23,7 @@
 #ifndef __VMatrix_h__
 #define __VMatrix_h__
 
+#include <cmath>
 #include <list>
 
 #include <TH1.h>


### PR DESCRIPTION
`std::ceil` requires `cmath`. Add the missing include.

I got this issue after a compiler update on my NixOS. 